### PR TITLE
Remove socket.destroy()

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,6 @@ module.exports = function(endpoint, opts) {
     if (opts.timeout !== false) request.setTimeout(opts.timeout || 10000, function() {
       // Clean up the socket
       request.setSocketKeepAlive(false);
-      request.socket.destroy();
 
       // Mark this as a gateway timeout
       res.status(504);


### PR DESCRIPTION
In the timeout code, when the call to `request.socket.destroy();` kills the socket and nothing after that call can return any data to the browser.

This causes 2 problems:
1) The browser get NO response but a dropped connection
2) Any middleware that tries to send anything through `res` will throw an exception.

By removing the call to `request.socket.destroy();` this allows the middleware to correctly respond and allows the browser to get a valid response.